### PR TITLE
Fix AccessToken expires format

### DIFF
--- a/spotishell/Private/Get-SpotifyAccessToken.ps1
+++ b/spotishell/Private/Get-SpotifyAccessToken.ps1
@@ -111,7 +111,7 @@ function Get-SpotifyAccessToken {
         $AccessTokenJSON = @{
           access_token = $Response."access_token";
           token_type   = $Response."token_type";
-          expires      = "$Expires";
+          expires      = Get-Date $Expires -Format 'u';
           scope        = $Response."scope";
         }
         $AccessTokenJSON | ConvertTo-Json -Depth 100 | Out-File -FilePath $AccessTokenFilePath

--- a/spotishell/Private/Get-SpotifyAuthCode.ps1
+++ b/spotishell/Private/Get-SpotifyAuthCode.ps1
@@ -54,14 +54,18 @@ function Get-SpotifyAuthCode {
     # opens the constructed uri in default browser on mac
     Write-Verbose "We are on Mac OS"
     open $URI
-  } elseif ($IsWindows) {
+  }
+  elseif ($IsLinux) {
+    throw 'Authorization Code Flow is not supported on Linux'
+  }
+  else { #so we are on Windows
     Write-Verbose "We are on Windows"
     rundll32 url.dll,FileProtocolHandler $URI
   }
 
   $Response = Read-Host "Paste the entire URL that it redirects you to"
-  $Response = $Response.Split("spotifyapi?")[1]
-  $SplitResponse = $Response.Split("&state=")
+  $Response = ($Response -Split 'spotifyapi?')[1]
+  $SplitResponse = $Response -Split '&state='
   $Code = $SplitResponse[0]
   $ResponseGuid = $SplitResponse[1]
 
@@ -75,6 +79,6 @@ function Get-SpotifyAuthCode {
     Write-Warning "We didn't successfully retrieve an auth code.  This may be due to expired credentials or wardbox messed up."
     return $Code
   }
-  $Code = $Code.Replace("code=", "")
+  $Code = $Code.Replace("?code=", "")
   return $Code
 }

--- a/spotishell/Private/Get-SpotifyUserAccessToken.ps1
+++ b/spotishell/Private/Get-SpotifyUserAccessToken.ps1
@@ -119,7 +119,7 @@ function Get-SpotifyUserAccessToken {
           access_token  = $Response."access_token"
           token_type    = $Response."token_type"
           scope         = $Response."scope"
-          expires_in    = $Expires
+          expires_in    = Get-Date $Expires -Format 'u';
           refresh_token = $Response."refresh_token"
         }
         $UserAccessTokenJSON | ConvertTo-Json -Depth 100 | Out-File -FilePath $UserAccessTokenFilePath


### PR DESCRIPTION
"$Expires" create a US format string (month/day/year time) in json
But read is done by piping it to Get-Date which consider localization.
In French system, the day after, the validity of token is misinterpreted and I got 401 error