### PR TITLE
Force array type if backup only one playlist

### DIFF
--- a/Spotishell/Public/Backup-Library.ps1
+++ b/Spotishell/Public/Backup-Library.ps1
@@ -33,7 +33,7 @@ function Backup-Library {
     $Backup = @{}
 
     if ($Type -contains 'Playlists' -or $Type -contains 'All') {
-        $Playlists = Get-CurrentUserPlaylists -ApplicationName $ApplicationName
+        $Playlists = [array](Get-CurrentUserPlaylists -ApplicationName $ApplicationName)
         $MyId = (Get-CurrentUserProfile).id
 
         # process followed playlists (owner is not me)

--- a/Spotishell/Public/Restore-Library.ps1
+++ b/Spotishell/Public/Restore-Library.ps1
@@ -83,7 +83,7 @@ function Restore-Library {
 
     if ($Type -contains 'SavedTracks' -or $Type -contains 'All') {
         if ($Backup.saved_tracks) {
-            Add-CurrentUserSavedTrack -Id $Backup.saved_trackss.id -ApplicationName $ApplicationName
+            Add-CurrentUserSavedTrack -Id $Backup.saved_tracks.id -ApplicationName $ApplicationName
         }
     }
 


### PR DESCRIPTION
if there is only one playlist in current user profile, Backup-Library fail because returned type is pscustomobject and not array