### PR TITLE
Send-PlaylistCoverImage fixed for PS7

### DIFF
--- a/Spotishell/Public/Playlists/Send-PlaylistCoverImage.ps1
+++ b/Spotishell/Public/Playlists/Send-PlaylistCoverImage.ps1
@@ -36,7 +36,7 @@ function Send-PlaylistCoverImage {
     $Uri = "https://api.spotify.com/v1/playlists/$Id/images"
 
     if ($ImagePath) {
-        $Body = [Convert]::ToBase64String((Get-Content $ImagePath -Encoding Byte))
+        $Body = [Convert]::ToBase64String((Get-Content $ImagePath -AsByteStream))
     }
 
     if ($ImageBase64) {

--- a/Spotishell/Public/Playlists/Send-PlaylistCoverImage.ps1
+++ b/Spotishell/Public/Playlists/Send-PlaylistCoverImage.ps1
@@ -36,7 +36,11 @@ function Send-PlaylistCoverImage {
     $Uri = "https://api.spotify.com/v1/playlists/$Id/images"
 
     if ($ImagePath) {
-        $Body = [Convert]::ToBase64String((Get-Content $ImagePath -AsByteStream))
+        if ($PSVersionTable.PSVersion.Major -ge 7) {
+            $Body = [Convert]::ToBase64String((Get-Content $ImagePath -AsByteStream))
+        } else {
+            $Body = [Convert]::ToBase64String((Get-Content $ImagePath -Encoding Byte))
+        }
     }
 
     if ($ImageBase64) {


### PR DESCRIPTION
Encoding value "Byte" is invalid in PS7, version check added