### PR TITLE
Resolved issue in Get-ArtistAlbums

### DIFF
--- a/Spotishell/Public/Artists/Get-ArtistAlbums.ps1
+++ b/Spotishell/Public/Artists/Get-ArtistAlbums.ps1
@@ -50,7 +50,7 @@ function Get-ArtistAlbums {
         if ($AppearsOn) { $IncludeGroups += 'appears_on' }
         if ($Compilation) { $IncludeGroups += 'compilation' }
 
-        Uri += '&' + ($IncludeGroups -join '%2C')
+        $Uri += '&' + ($IncludeGroups -join '%2C')
     }
 
     # build a fake Response to start the machine


### PR DESCRIPTION
The $Uri variable was not prefixed with a dollar, causing the following error when running `Get-ArtistAlbum "ID" -Album -Single`:

Uri: C:\Program Files\WindowsPowerShell\Modules\spotishell\1.0.2\Public\Artists\Get-ArtistAlbums.ps1:53 Line |
  53 |          Uri += '&' + ($IncludeGroups -join '%2C')
     |          ~~~
     | The term 'Uri' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the
     | spelling of the name, or if a path was included, verify that the path is correct and try again.