### PR TITLE
Fix Backup and Restore of entire Library

### DIFF
--- a/Spotishell/Public/Backup-Library.ps1
+++ b/Spotishell/Public/Backup-Library.ps1
@@ -79,5 +79,5 @@ function Backup-Library {
         $Backup.saved_tracks = ((Get-CurrentUserSavedTracks -ApplicationName $ApplicationName).track | Select-Object name, id)
     }
 
-    Set-Content -Path $Path -Value (ConvertTo-Json -Depth 10 -InputObject $Backup) -Encoding Unicode
+    Set-Content -Path $Path -Value (ConvertTo-Json -Depth 10 -InputObject $Backup) -Encoding UTF8
 }

--- a/Spotishell/Public/Backup-Library.ps1
+++ b/Spotishell/Public/Backup-Library.ps1
@@ -50,9 +50,9 @@ function Backup-Library {
                 collaborative = $playlist.collaborative
                 description   = $playlist.description
                 tracks        = (Get-PlaylistItems -Id $playlist.id -ApplicationName $ApplicationName).track.uri
-                images        = &{
-                    $image = ($playlist.images | Sort-Object -Property height -Descending)[0]
-                    if ($null -ne $image) {
+                image         = & {
+                    if ($null -ne $playlist.images) {
+                        $image = ($playlist.images | Sort-Object -Property height -Descending)[0]
                         $ProgressPreference = 'SilentlyContinue'
                         $imgBytes = (Invoke-WebRequest $image.url).Content
                         $ProgressPreference = 'Continue'

--- a/Spotishell/Public/Backup-Library.ps1
+++ b/Spotishell/Public/Backup-Library.ps1
@@ -79,5 +79,5 @@ function Backup-Library {
         $Backup.saved_tracks = ((Get-CurrentUserSavedTracks -ApplicationName $ApplicationName).track | Select-Object name, id)
     }
 
-    Set-Content -Path $Path -Value (ConvertTo-Json -InputObject $Backup) -Encoding Unicode
+    Set-Content -Path $Path -Value (ConvertTo-Json -Depth 10 -InputObject $Backup) -Encoding Unicode
 }

--- a/Spotishell/Public/Backup-Library.ps1
+++ b/Spotishell/Public/Backup-Library.ps1
@@ -34,7 +34,7 @@ function Backup-Library {
 
     if ($Type -contains 'Playlists' -or $Type -contains 'All') {
         $Playlists = [array](Get-CurrentUserPlaylists -ApplicationName $ApplicationName)
-        $MyId = (Get-CurrentUserProfile).id
+        $MyId = (Get-CurrentUserProfile -ApplicationName $ApplicationName).id
 
         # process followed playlists (owner is not me)
         $Backup.followed_playlists = foreach ($playlist in $Playlists.Where( { $_.owner.id -ne $MyId })) {

--- a/Spotishell/Public/Restore-Library.ps1
+++ b/Spotishell/Public/Restore-Library.ps1
@@ -28,7 +28,7 @@ function Restore-Library {
         $ApplicationName
     )
 
-    $Backup = Get-Content -Path $Path -Raw | ConvertFrom-Json
+    $Backup = Get-Content -Path $Path -Encoding UTF8 -Raw | ConvertFrom-Json
 
     if ($Type -contains 'Playlists' -or $Type -contains 'All') {
         $MyId = (Get-CurrentUserProfile -ApplicationName $ApplicationName).id

--- a/Spotishell/Public/Restore-Library.ps1
+++ b/Spotishell/Public/Restore-Library.ps1
@@ -31,15 +31,15 @@ function Restore-Library {
     $Backup = Get-Content -Path $Path -Raw | ConvertFrom-Json
 
     if ($Type -contains 'Playlists' -or $Type -contains 'All') {
-        $MyId = (Get-CurrentUserProfile).id
+        $MyId = (Get-CurrentUserProfile -ApplicationName $ApplicationName).id
 
         # process followed playlists
         foreach ($playlist in $Backup.followed_playlists) {
-            Add-FollowedPlaylist -Id $playlist.id -Public $playlist.public
+            Add-FollowedPlaylist -Id $playlist.id -Public $playlist.public -ApplicationName $ApplicationName
         }
 
         # process my playlists
-        $MyPlaylists = Get-CurrentUserPlaylists
+        $MyPlaylists = Get-CurrentUserPlaylists -ApplicationName $ApplicationName
         foreach ($playlist in $Backup.my_playlists) {
             # if playlist with this id exists
             if ($MyPlaylists.id -contains $playlist.id) {
@@ -55,7 +55,7 @@ function Restore-Library {
                 $Id = (New-Playlist -UserId $MyId -Name $playlist.name -Public $playlist.public -Collaborative $playlist.collaborative -Description $playlist.description -ApplicationName $ApplicationName).id
             }
             # set tracks
-            Set-PlaylistItems -Id $Id -Uris $playlist.tracks | Out-Null
+            Set-PlaylistItems -Id $Id -Uris $playlist.tracks -ApplicationName $ApplicationName | Out-Null
             # set image
             if ($playlist.image) { Send-PlaylistCoverImage -Id $Id -ImageBase64 $playlist.image | Out-Null }
         }

--- a/Spotishell/Public/Restore-Library.ps1
+++ b/Spotishell/Public/Restore-Library.ps1
@@ -57,9 +57,7 @@ function Restore-Library {
             # set tracks
             Set-PlaylistItems -Id $Id -Uris $playlist.tracks | Out-Null
             # set image
-            foreach ($img in $playlist.images) {
-                if ($img) { Send-PlaylistCoverImage -Id $Id -ImageBase64 $img | Out-Null }
-            }
+            if ($playlist.image) { Send-PlaylistCoverImage -Id $Id -ImageBase64 $playlist.image | Out-Null }
         }
     }
 


### PR DESCRIPTION
 - Fix incorrect playlist tracks list in Backup : Default PS JSON depth is 2 but playlist tracks reach depth of 3. I've pushed level to 10 to avoid any other issues
 - Fix playlist image backup and restore : Got issues where playlist doesn't have image and now keep only the bigger one
 - Add forgotten ApplicationName parameter in Backup-Library and Restore-Library
 - Set Encoding of Library backup to UTF8 (PS5.1 and above are not consistent on this topic)