### PR TITLE
Change default redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Get-Command -Module Spotishell
 ```powershell
 New-SpotifyApplication -ClientId "blahblahblah" -ClientSecret "blahblahblahblah"
 ```
-5. Add "http://localhost:8080/spotishell" as a redirect URL in your Spotify app settings
+5. Add "http://127.0.0.1:8080/spotishell" as a redirect URL in your Spotify app settings
 [spotify developer Dashboard](https://developer.spotify.com/dashboard)
 
 6. Give it a whirl!

--- a/Spotishell/Public/New-SpotifyApplication.ps1
+++ b/Spotishell/Public/New-SpotifyApplication.ps1
@@ -33,7 +33,7 @@ function New-SpotifyApplication {
         $ClientSecret,
 
         [String]
-        $RedirectUri = 'http://localhost:8080/spotishell'
+        $RedirectUri = 'http://127.0.0.1:8080/spotishell'
     )
 
     $StorePath = Get-StorePath


### PR DESCRIPTION
Spotify no longer allows using `localhost` as a Redirect URIs for new apps, even if it's a loopback address, and will require all exiting apps to migrate by November 2025 ([source](https://developer.spotify.com/documentation/web-api/concepts/redirect_uri)). Changing the default value and the documentation is enough to keep it working.