### PR TITLE
Fix publish workflow to exclude integration tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,8 @@ jobs:
           Import-Module Pester
 
           $config = New-PesterConfiguration
-          $config.Run.Path = './Tests'
+          # Only run unit tests, exclude integration tests (require API credentials)
+          $config.Run.Path = './Tests/Spotishell.Tests.ps1'
           $config.Run.Exit = $true
           $config.Output.Verbosity = 'Detailed'
 


### PR DESCRIPTION
Integration tests require Spotify API credentials which aren't available in the publish workflow. Only run unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish workflow to execute only unit tests, excluding integration tests that require external API credentials during the publishing process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->